### PR TITLE
feat: render with the standard easy6502 16-color palette

### DIFF
--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -40,9 +40,31 @@ void Frontend::shutdown() {
 }
 
 void Frontend::map_to_rgb(Byte v, Byte& r, Byte& g, Byte& b) {
-    if (v == 0) { r = g = b = 0; }
-    else if (v == 1) { r = g = b = 255; }
-    else { r = g = b = (Byte)(v * 16); }
+    // The standard easy6502 16-color palette; screen bytes use the low
+    // nibble as a color index, matching the ROMs written for it (the
+    // bundled snake game picks its apple color from $FE this way).
+    static const Byte palette[16][3] = {
+        {0x00, 0x00, 0x00}, // 0  black
+        {0xFF, 0xFF, 0xFF}, // 1  white
+        {0x88, 0x00, 0x00}, // 2  red
+        {0xAA, 0xFF, 0xEE}, // 3  cyan
+        {0xCC, 0x44, 0xCC}, // 4  purple
+        {0x00, 0xCC, 0x55}, // 5  green
+        {0x00, 0x00, 0xAA}, // 6  blue
+        {0xEE, 0xEE, 0x77}, // 7  yellow
+        {0xDD, 0x88, 0x55}, // 8  orange
+        {0x66, 0x44, 0x00}, // 9  brown
+        {0xFF, 0x77, 0x77}, // 10 light red
+        {0x33, 0x33, 0x33}, // 11 dark grey
+        {0x77, 0x77, 0x77}, // 12 grey
+        {0xAA, 0xFF, 0x66}, // 13 light green
+        {0x00, 0x88, 0xFF}, // 14 light blue
+        {0xBB, 0xBB, 0xBB}  // 15 light grey
+    };
+    const Byte* c = palette[v & 0x0F];
+    r = c[0];
+    g = c[1];
+    b = c[2];
 }
 
 void Frontend::draw_if_changed(const Byte* screen) {


### PR DESCRIPTION
The bundled snake ROM is the classic easy6502 snake game, and easy6502 ROMs treat screen bytes as indices into its standard 16-color palette (snake's apple color comes from the random byte at `$FE`, so it cycles through colors 1–15). The frontend currently maps everything to greyscale, so the apple renders as shades of grey instead of its intended colors.

This PR replaces the greyscale mapping in `map_to_rgb` with the standard easy6502 palette (black, white, red, cyan, purple, green, blue, yellow, orange, brown, light red, dark grey, grey, light green, light blue, light grey), masking to the low nibble exactly as easy6502 does. Values 0 and 1 map to black/white as before, so the snake body and background are pixel-identical — only colors 2–15 change. Any ROM written against the easy6502 spec now renders with correct colors.

Builds warning-free; the game plays as before with a properly colorful apple.

cc @hand-burger — with this plus the ROM-loading fix in #2, anything built on https://skilldrick.github.io/easy6502/ should drop straight into the emulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)